### PR TITLE
Stabilise the studio image visibility threshold

### DIFF
--- a/src/pages/studio.tsx
+++ b/src/pages/studio.tsx
@@ -32,8 +32,8 @@ export default function Studio () {
     const desktopPhotoShowWidth = 340
 
     const updatePhotoVisibility = () => {
-      const styles = window.getComputedStyle(container)
-      const gap = Number.parseFloat(styles.columnGap) || 0
+      const computedStyles = window.getComputedStyle(container)
+      const gap = Number.parseFloat(computedStyles.columnGap) || 0
       const usedWidth = studioText.offsetWidth + teamText.offsetWidth + (gap * 2)
       const availablePhotoWidth = container.clientWidth - usedWidth
 
@@ -44,16 +44,19 @@ export default function Studio () {
     }
 
     const animationFrame = window.requestAnimationFrame(updatePhotoVisibility)
+    let observer: ResizeObserver | null = null
 
-    const observer = new ResizeObserver(updatePhotoVisibility)
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(updatePhotoVisibility)
 
-    observer.observe(container)
-    observer.observe(studioText)
-    observer.observe(teamText)
+      observer.observe(container)
+      observer.observe(studioText)
+      observer.observe(teamText)
+    }
 
     return () => {
       window.cancelAnimationFrame(animationFrame)
-      observer.disconnect()
+      observer?.disconnect()
     }
   }, [isDesktop])
   

--- a/src/pages/studio.tsx
+++ b/src/pages/studio.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import useViewport from '@lib/useViewport'
 
 import BackToTop from '@components/top'
@@ -10,7 +10,52 @@ import styles from '@styles/Pages.module.css'
 
 export default function Studio () {
   const [width] = useViewport()
-  const imageRef = useRef<HTMLImageElement>(null)
+  const isDesktop = width >= 1001
+
+  // The desktop photo is only shown if there is enough space for it, which depends on the width of the text and the gap between them. 
+  // This effect uses a ResizeObserver to watch for changes in the size of the container and text elements, and updates the visibility of the photo accordingly.
+  const containerRef = useRef<HTMLDivElement>(null)
+  const studioTextRef = useRef<HTMLDivElement>(null)
+  const teamTextRef = useRef<HTMLDivElement>(null)
+  const [showDesktopPhoto, setShowDesktopPhoto] = useState(false)
+
+  useEffect(() => {
+    if (!isDesktop) return
+
+    const container = containerRef.current
+    const studioText = studioTextRef.current
+    const teamText = teamTextRef.current
+
+    if (!container || !studioText || !teamText) return
+
+    const desktopPhotoMinWidth = 300
+    const desktopPhotoShowWidth = 340
+
+    const updatePhotoVisibility = () => {
+      const styles = window.getComputedStyle(container)
+      const gap = Number.parseFloat(styles.columnGap) || 0
+      const usedWidth = studioText.offsetWidth + teamText.offsetWidth + (gap * 2)
+      const availablePhotoWidth = container.clientWidth - usedWidth
+
+      setShowDesktopPhoto((current) => {
+        if (current) return availablePhotoWidth >= desktopPhotoMinWidth
+        return availablePhotoWidth >= desktopPhotoShowWidth
+      })
+    }
+
+    const animationFrame = window.requestAnimationFrame(updatePhotoVisibility)
+
+    const observer = new ResizeObserver(updatePhotoVisibility)
+
+    observer.observe(container)
+    observer.observe(studioText)
+    observer.observe(teamText)
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame)
+      observer.disconnect()
+    }
+  }, [isDesktop])
   
   return <>
     <Head>
@@ -18,7 +63,7 @@ export default function Studio () {
       <meta name="description" content="We are a multi-cultural studio of dedicated and passionate architects that bring a variety of experiences and strengths to each project." />
     </Head>
     <Wrapper>
-      <div className={styles.container}>
+      <div className={styles.container} ref={containerRef}>
         {width <= 1000 && <>
           <ExportedImage
             src="/images/studio/Photo_mobile.jpg"
@@ -39,25 +84,23 @@ export default function Studio () {
           />
           <BackToTop />
         </>}
-        {width >= 1001 && <>
-          {/* eslint-disable-next-line react-hooks/refs */}
-          {(imageRef.current?.clientWidth ?? 501) > 500 &&
+        {isDesktop && <>
+          {showDesktopPhoto &&
             <ExportedImage
               src="/images/studio/Photo_desktop.jpg"
               alt="Photo of architectural studio"
               fill
               className={styles.image}
-              ref={imageRef}
             />
           } 
-          <div className={styles.text}>
+          <div className={styles.text} ref={studioTextRef}>
             <ExportedImage 
               src="/images/studio/Studio_desktop.png"
               alt="Text describing the studio"
               fill
             />
           </div>
-          <div className={styles.text}>
+          <div className={styles.text} ref={teamTextRef}>
             <ExportedImage
               src="/images/studio/Team_desktop.png"
               alt="Text listing team members"

--- a/src/styles/Pages.module.css
+++ b/src/styles/Pages.module.css
@@ -1,40 +1,10 @@
+/* base */
 .container {
   position: relative;
   display: flex;
   flex-direction: row;
   gap: 1rem;
   padding: 1rem;
-}
-
-@media (min-width: 1001px) {
-  .container {
-    width: calc(100vw - 350px);
-    max-width: 100%;
-    height: calc(100vh - 2rem);
-    max-height: 1200px;
-  }
-
-  .contact {
-    justify-content: space-between;
-  }
-
-  .text {
-    background-color: #ebebed;
-  }
-}
-
-@media (max-width: 1000px) {
-  .container {
-    flex-direction: column;
-    justify-content: start;
-    width: 100%;
-    overflow: hidden;
-  }
-
-  .container > img:first-child {
-    aspect-ratio: 1/1;
-    object-fit: cover;
-  }
 }
 
 .container > * {
@@ -73,7 +43,37 @@
   bottom: 7%;
 }
 
+/* desktop */
+@media (min-width: 1001px) {
+  .container {
+    width: 100%;
+    height: max(800px, calc(100vh - 2rem));
+    max-height: 1200px;
+  }
+
+  .contact {
+    justify-content: space-between;
+  }
+
+  .text {
+    background-color: #ebebed;
+  }
+}
+
+/* mobile */
 @media (max-width: 1000px) {
+  .container {
+    flex-direction: column;
+    justify-content: start;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  .container > img:first-child {
+    aspect-ratio: 1/1;
+    object-fit: cover;
+  }
+
   .text > img {
     margin: 0% -10%;
     width: 120% !important;


### PR DESCRIPTION
## Summary
- Replace the studio photo’s self-referential `useRef` sizing check with a `ResizeObserver`-based layout measurement.
- Add a small show/hide hysteresis so the image does not flicker when the window is resized near the breakpoint.
- Keep the desktop/mobile behaviour aligned with the available space in the layout.

## Testing
- `npm run lint` passed.
- `npm run build` passed.
- Verified the `/studio` route loads successfully in the local app.